### PR TITLE
Extend the result vector by a slice rather than pushing bytes

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -415,15 +415,11 @@ impl Host {
             match address {
                 IpAddr::V4(ip4) => {
                     num_v4 += 1;
-                    for octet in ip4.octets() {
-                        buf_addrs.push(octet)
-                    }
+                    buf_addrs.extend_from_slice(ip4.octets().as_slice());
                 }
                 IpAddr::V6(ip6) => {
                     num_v6 += 1;
-                    for octet in ip6.octets() {
-                        buf_addrs.push(octet)
-                    }
+                    buf_addrs.extend_from_slice(ip6.octets().as_slice());
                 }
             }
         }


### PR DESCRIPTION
This makes the code a bit cleaner and gives the stdlib / compiler more information about what we actually want to achieve. The previous assembly looked rather bulky when recreating it on godbolt.

Running some hacky criterion benchmarks (after marking handlers public, changing the entire thing to be a library with a binary rather than just a binary, ..) the performance gains are roughly 20% on serializing host results.